### PR TITLE
Fix: replace {{clientOptions}}

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 var Duplex = require('stream').Duplex;
 var browserChannel = require('browserchannel').server;
 var through = require('through');
+var path = require('path');
 
 // Pass in pass through stream
 module.exports = function(store, serverOptions, clientOptions) {
@@ -12,7 +13,7 @@ module.exports = function(store, serverOptions, clientOptions) {
   // needed to connect to the corresponding server by injecting them into the
   // file during bundling
   store.on('bundle', function(bundle) {
-    var browserFilename = __dirname + '/browser.js';
+    var browserFilename = path.join(__dirname, 'browser.js');
     bundle.transform(function(filename) {
       if (filename !== browserFilename) return through();
       var file = '';


### PR DESCRIPTION
[Here](https://github.com/codeparty/racer-browserchannel/blob/master/lib/server.js#L17) 'filename' and 'browserFilename' are never equal on windows.

```
filename = ... \lib\browser.js
browserFilename = ... \lib/browser.js
```
