### PR TITLE
Overriding of base path

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -3,7 +3,7 @@ var BCSocket = require('browserchannel/dist/bcsocket-uncompressed').BCSocket;
 
 var CLIENT_OPTIONS = {{clientOptions}};
 
-racer.Model.prototype._createSocket = function() {
-  var base = CLIENT_OPTIONS.base || '/channel';
+racer.Model.prototype._createSocket = function(data) {
+  var base = data.base || CLIENT_OPTIONS.base || '/channel';
   return new BCSocket(base, CLIENT_OPTIONS);
 };


### PR DESCRIPTION
Allow overriding of base path, i.e., using racer.createModel({ base: '/path/to/channel' }).
