### PR TITLE
Factor out the browserify transform so that it can be used in a gulp task

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -1,0 +1,30 @@
+var path = require('path');
+var through = require('through');
+
+module.exports = function(clientOptions) {
+  if (!clientOptions) clientOptions = {};
+  if (clientOptions.reconnect == null) clientOptions.reconnect = true;
+  var clientOptionsJson = JSON.stringify(clientOptions);
+
+  // Add the client side script to the Browserify bundle. Set the clientOptions
+  // needed to connect to the corresponding server by injecting them into the
+  // file during bundling
+  return function(bundle) {
+    var browserFilename = path.join(__dirname, 'browser.js');
+    bundle.transform(function(filename) {
+      if (filename !== browserFilename) return through();
+      var file = '';
+      return through(
+        function write(data) {
+          file += data;
+        }
+      , function end() {
+          var rendered = file.replace('{{clientOptions}}', clientOptionsJson);
+          this.queue(rendered);
+          this.queue(null);
+        }
+      );
+    });
+    bundle.add(browserFilename);
+  };
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,35 +1,11 @@
 var Duplex = require('stream').Duplex;
 var browserChannel = require('browserchannel').server;
-var through = require('through');
-var path = require('path');
+var bundle = require('./bundle');
 
 // Pass in pass through stream
 module.exports = function(store, serverOptions, clientOptions) {
-  if (!clientOptions) clientOptions = {};
-  if (clientOptions.reconnect == null) clientOptions.reconnect = true;
-  var clientOptionsJson = JSON.stringify(clientOptions);
-
-  // Add the client side script to the Browserify bundle. Set the clientOptions
-  // needed to connect to the corresponding server by injecting them into the
-  // file during bundling
-  store.on('bundle', function(bundle) {
-    var browserFilename = path.join(__dirname, 'browser.js');
-    bundle.transform(function(filename) {
-      if (filename !== browserFilename) return through();
-      var file = '';
-      return through(
-        function write(data) {
-          file += data;
-        }
-      , function end() {
-          var rendered = file.replace('{{clientOptions}}', clientOptionsJson);
-          this.queue(rendered);
-          this.queue(null);
-        }
-      );
-    });
-    bundle.add(browserFilename);
-  });
+  // add the client side script to the Browserify bundle
+  store.on('bundle', bundle(clientOptions));
 
   var middleware = browserChannel(serverOptions, function(client, connectRequest) {
     var rejected = false;


### PR DESCRIPTION
racer-browserchannel and racer-highway are made to be used with browserify at runtime, however other architectures are possible (desirable?) such as pre-creating a script in a gulp or grunt task.

This change enables the code to be reused in that way -- see https://github.com/Biggerflip/racer-highway/blob/b558f69853d4f0c53db48735807fc0c56405c389/README.md#browserify

Client options can be overridden in the call to racerClientBundle(clientOptions) if necessary.