### PR TITLE
Debrowserify module

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,5 @@
-var racer = require('racer');
-var BCSocket = require('browserchannel/dist/bcsocket-uncompressed').BCSocket;
+const racer = require('racer');
+const BCSocket = require('browserchannel/dist/bcsocket-uncompressed').BCSocket;
 
 const DEFAULT_CLIENT_OPTIONS = {
   reconnect: true,

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,14 +1,21 @@
 var racer = require('racer');
 var BCSocket = require('browserchannel/dist/bcsocket-uncompressed').BCSocket;
 
-var CLIENT_OPTIONS = {{clientOptions}};
+const DEFAULT_CLIENT_OPTIONS = {
+  reconnect: true,
+  base: '/channel',
+}
 
-racer.Model.prototype._createSocket = function(bundle) {
-  var options = CLIENT_OPTIONS;
-  if (bundle.browserChannel) {
-    options = racer.util.mergeInto({}, options);
-    racer.util.mergeInto(options, bundle.browserChannel);
+module.exports = function init(clientOptions) {
+  if (!process.browser) {
+    return;
   }
-  var base = options.base || '/channel';
-  return new BCSocket(base, options);
-};
+  const options = Object.asssign({}, DEFAULT_CLIENT_OPTIONS, clientOptions);
+
+  racer.Model.prototype._createSocket = function(bundle) {
+    if (bundle.browserChannel) {
+      racer.util.mergeInto(options, bundle.browserChannel);
+    }
+    return new BCSocket(options.base, options);
+  };
+}

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -10,7 +10,7 @@ module.exports = function init(clientOptions) {
   if (!process.browser) {
     return;
   }
-  const options = Object.asssign({}, DEFAULT_CLIENT_OPTIONS, clientOptions);
+  const options = Object.assign({}, DEFAULT_CLIENT_OPTIONS, clientOptions);
 
   racer.Model.prototype._createSocket = function(bundle) {
     if (bundle.browserChannel) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,42 +1,13 @@
 var Duplex = require('stream').Duplex;
 var browserChannel = require('browserchannel').server;
-var through = require('through');
 var path = require('path');
 var util = require('util');
 
-// Pass in pass through stream
-module.exports = function(backend, serverOptions, clientOptions) {
-  if (!clientOptions) clientOptions = {};
-  if (clientOptions.reconnect == null) clientOptions.reconnect = true;
-  var clientOptionsJson = JSON.stringify(clientOptions);
-
-  // Add the client side script to the Browserify bundle. Set the clientOptions
-  // needed to connect to the corresponding server by injecting them into the
-  // file during bundling
-  backend.on('bundle', function(bundle) {
-    var browserFilename = path.join(__dirname, 'browser.js');
-    bundle.transform(function(filename) {
-      if (filename !== browserFilename) return through();
-      var file = '';
-      return through(
-        function write(data) {
-          file += data;
-        }
-      , function end() {
-          var rendered = file.replace('{{clientOptions}}', clientOptionsJson);
-          this.queue(rendered);
-          this.queue(null);
-        }
-      );
-    });
-    bundle.add(browserFilename);
-  });
-
-  var middleware = browserChannel(serverOptions, function(client, connectRequest) {
+module.exports = function(backend, serverOptions) {
+  return  browserChannel(serverOptions, function(client, connectRequest) {
     var stream = createStream(client);
     backend.listen(stream, connectRequest);
   });
-  return middleware;
 };
 
 /**

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,5 @@
 const Duplex = require('stream').Duplex;
 const browserChannel = require('browserchannel').server;
-const path = require('path');
 const util = require('util');
 
 module.exports = function(backend, serverOptions) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,11 +1,11 @@
-var Duplex = require('stream').Duplex;
-var browserChannel = require('browserchannel').server;
-var path = require('path');
-var util = require('util');
+const Duplex = require('stream').Duplex;
+const browserChannel = require('browserchannel').server;
+const path = require('path');
+const util = require('util');
 
 module.exports = function(backend, serverOptions) {
-  return  browserChannel(serverOptions, function(client, connectRequest) {
-    var stream = createStream(client);
+  return browserChannel(serverOptions, function(client, connectRequest) {
+    const stream = createStream(client);
     backend.listen(stream, connectRequest);
   });
 };
@@ -16,10 +16,10 @@ module.exports = function(backend, serverOptions) {
  * @return {Duplex} stream
  */
 function createStream(client) {
-  var stream = new ClientStream(client);
+  const stream = new ClientStream(client);
 
   client.on('message', function onMessage(message) {
-    var data;
+    let data;
     try {
       data = JSON.parse(message);
     } catch (err) {
@@ -43,7 +43,7 @@ function ClientStream(client) {
 
   this.client = client;
 
-  var self = this;
+  const self = this;
 
   this.on('error', function(error) {
     console.warn('BrowserChannel client message stream error', error.stack || error);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "browserchannel": "^2.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "np": "^7.6.3"
+  },
   "peerDependencies": {
     "racer": "*"
   },

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "browserchannel": "^2.0"
   },
-  "devDependencies": {
-    "np": "^7.6.3"
-  },
   "peerDependencies": {
     "racer": "*"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "peerDependencies": {
     "racer": "*"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "optionalDependencies": {},
   "bugs": {
     "url": "https://github.com/derbyjs/racer-browserchannel/issues"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
   },
   "version": "0.5.0",
   "main": "./lib/server.js",
-  "browser": {
-    "main": "./lib/browser.js"
-  },
+  "browser": "./lib/browser.js",
   "dependencies": {
     "browserchannel": "^2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "racer-browserchannel",
+  "name": "@derbyjs/racer-browserchannel",
   "description": "Browserchannel socket plugin for Racer",
   "homepage": "http://racerjs.com/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "main": "./lib/browser.js"
   },
   "dependencies": {
-    "browserchannel": "^2.0",
-    "through": "^2.3.4"
+    "browserchannel": "^2.0"
   },
   "devDependencies": {},
+  "peerDependencies": {
+    "racer": "*"
+  },
   "optionalDependencies": {},
   "bugs": {
     "url": "https://github.com/derbyjs/racer-browserchannel/issues"


### PR DESCRIPTION
- Change package publishing to publish under `@derbyjs` org
- Removes dependency on `browserify` injection and string replacement for configuration.

Import in client side app, and pass configuration:
```
let channel = require('racer-browserchannel/lib/browser');
channel(clientOptions);
```


